### PR TITLE
[2.x] feat: Hold tracking until the visitor consents

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,7 @@ jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@2.x
     with:
-      enable_backend_testing: false
+      enable_backend_testing: true
       enable_phpstan: true
 
       backend_directory: .

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 composer.lock
 js/dist
 .aider*
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
     },
     "require-dev": {
         "flarum/phpstan": "^2.0.0",
-        "flarum/testing": "^2.0.0"
+        "flarum/testing": "^2.0.0",
+        "fof/cookie-consent": "^2.0@dev"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     "require-dev": {
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0",
-        "fof/cookie-consent": "^2.0@dev"
+        "fof/cookie-consent": "^2.0.0"
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",

--- a/composer.json
+++ b/composer.json
@@ -51,15 +51,20 @@
                 "name": "fas fa-chart-line",
                 "backgroundColor": "#e74c3c",
                 "color": "#fff"
-            }
-        },
-        "flagrow": {
-            "discuss": "https://discuss.flarum.org/d/1983"
+            },
+            "optional-dependencies": [
+                "fof/cookie-consent"
+            ]
         },
         "flarum-cli": {
             "modules": {
                 "githubActions": true
             }
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "FoF\\Analytics\\Tests\\": "tests/"
         }
     },
     "autoload": {
@@ -76,10 +81,18 @@
     },
     "scripts": {
         "analyse:phpstan": "phpstan analyse",
+        "test": [
+            "@test:integration"
+        ],
+        "test:integration": "phpunit -d memory_limit=512M -c tests/phpunit.integration.xml",
+        "test:setup": "@php tests/integration/setup.php",
         "clear-cache:phpstan": "phpstan clear-result-cache"
     },
     "scripts-descriptions": {
-        "analyse:phpstan": "Run static analysis"
+        "analyse:phpstan": "Run static analysis",
+        "test": "Runs all tests.",
+        "test:integration": "Runs all integration tests.",
+        "test:setup": "Sets up a database for use with integration tests. Execute this only once."
     },
     "minimum-stability": "beta",
     "prefer-stable": true

--- a/extend.php
+++ b/extend.php
@@ -12,6 +12,8 @@
 namespace FoF\Analytics;
 
 use Flarum\Extend;
+use FoF\Analytics\Consent\Cookies;
+use FoF\CookieConsent\Extend\CookieConsent;
 
 return [
     (new Extend\Frontend('forum'))
@@ -22,4 +24,26 @@ return [
         ->js(__DIR__.'/js/dist/admin.js'),
 
     new Extend\Locales(__DIR__.'/resources/locale'),
+
+    // Declare what tracking stores and hold its scripts until the visitor
+    // consents. Wrapped in whenExtensionEnabled so the CookieConsent classes
+    // are only referenced when that extension is installed — without it the
+    // classes do not exist and constructing one would be fatal.
+    //
+    // Each provider is declared only when it is in use, so a forum running
+    // Google alone does not list Matomo's cookies to visitors.
+    (new Extend\Conditional())
+        ->whenExtensionEnabled('fof-cookie-consent', fn () => [
+            (new Extend\Conditional())
+                ->whenSetting('fof-analytics.statusGoogle', true, fn () => [
+                    (new CookieConsent())
+                        ->category(Cookies::CATEGORY, fn ($c) => Cookies::google($c))
+                        ->gate(Cookies::CATEGORY),
+                ])
+                ->whenSetting('fof-analytics.statusPiwik', true, fn () => [
+                    (new CookieConsent())
+                        ->category(Cookies::CATEGORY, fn ($c) => Cookies::matomo($c))
+                        ->gate(Cookies::CATEGORY),
+                ]),
+        ]),
 ];

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -2,18 +2,36 @@ import { extend } from 'flarum/common/extend';
 import app from 'flarum/forum/app';
 import Page from 'flarum/common/components/Page';
 
+/**
+ * Configure Google Analytics, supplying the user ID for cross-device tracking.
+ *
+ * Returns whether it ran: with fof/cookie-consent installed the tracking script
+ * is held inert until the visitor accepts, so `gtag` may not exist yet.
+ */
+function configureGoogle() {
+  if (!app.data.googleTrackingCode || typeof gtag === 'undefined') return false;
+
+  gtag('config', app.data.googleTrackingCode);
+
+  if (app.session.user) {
+    gtag('config', app.data.googleTrackingCode, {
+      user_id: app.session.user.id(),
+    });
+  }
+
+  return true;
+}
+
 app.initializers.add('fof-analytics', () => {
   // Supply user IDs for cross-device tracking
   setTimeout(() => {
-    if (app.data.googleTrackingCode && typeof gtag !== 'undefined') {
-      gtag('config', app.data.googleTrackingCode);
+    if (configureGoogle()) return;
 
-      if (app.session.user) {
-        gtag('config', app.data.googleTrackingCode, {
-          user_id: app.session.user.id(),
-        });
-      }
-    }
+    // The script was held pending consent. fof/cookie-consent activates it
+    // when the visitor accepts, so configure it then instead — otherwise this
+    // first `config` call would be lost and only later page views tracked.
+    window.addEventListener('cc:onConsent', configureGoogle);
+    window.addEventListener('cc:onChange', configureGoogle);
   }, 0);
 
   extend(Page.prototype, 'oninit', function () {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,11 +9,3 @@ parameters:
   excludePaths:
     - *.blade.php
   databaseMigrationsPath: ['migrations']
-
-  # fof/cookie-consent is an optional dependency and is not installed in CI,
-  # so its classes cannot be resolved. Remove these once it is released.
-  ignoreErrors:
-    - '#unknown class FoF\\CookieConsent\\#'
-    - '#class FoF\\CookieConsent\\[A-Za-z\\]+ not found#'
-    - '#has invalid type FoF\\CookieConsent\\#'
-  

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,4 +9,11 @@ parameters:
   excludePaths:
     - *.blade.php
   databaseMigrationsPath: ['migrations']
+
+  # fof/cookie-consent is an optional dependency and is not installed in CI,
+  # so its classes cannot be resolved. Remove these once it is released.
+  ignoreErrors:
+    - '#unknown class FoF\\CookieConsent\\#'
+    - '#class FoF\\CookieConsent\\[A-Za-z\\]+ not found#'
+    - '#has invalid type FoF\\CookieConsent\\#'
   

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -32,3 +32,17 @@ fof-analytics:
 
         matomo-widget:
             title: Matomo
+
+    forum:
+        consent:
+            cookies:
+                ga: Tells visits apart, so repeat visits are not counted as new people.
+                gat: Limits how often data is sent to Google.
+                gid: Tells visits apart, kept for 24 hours.
+                utm: Older Google Analytics cookies, recording how you reached the site.
+                pk_id: Tells visits apart, so repeat visits are not counted as new people.
+                pk_ses: Tracks the current visit, kept for 30 minutes.
+                pk_ref: Records how you reached the site.
+                pk_cvar: Stores custom details about the current visit.
+                pk_hsr: Records the current visit for heatmaps and session recording.
+                matomo_sessid: Keeps your Matomo session while it is being recorded.

--- a/src/Consent/Cookies.php
+++ b/src/Consent/Cookies.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of fof/analytics.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Analytics\Consent;
+
+use FoF\CookieConsent\Category;
+
+/**
+ * The cookies each analytics provider sets, declared so fof/cookie-consent can
+ * erase them when a visitor declines and describe them in the preferences
+ * dialog.
+ *
+ * Which of these are declared is decided in extend.php, so a forum running
+ * Google alone does not tell visitors it stores Matomo's cookies.
+ */
+class Cookies
+{
+    /** The consent category these belong to. */
+    public const CATEGORY = 'analytics';
+
+    private const T = 'fof-analytics.forum.consent';
+
+    /**
+     * Google Analytics and Tag Manager.
+     *
+     * `^_ga` covers the base cookie and GA4's per-property `_ga_XXXXXXX`;
+     * `^_gat` covers its throttling cookies.
+     */
+    public static function google(Category $category): void
+    {
+        $category
+            ->cookiePattern('^_ga', self::T.'.cookies.ga')
+            ->cookiePattern('^_gat', self::T.'.cookies.gat')
+            ->cookie('_gid', self::T.'.cookies.gid')
+            ->cookiePattern('^__utm', self::T.'.cookies.utm');
+
+        self::finish($category);
+    }
+
+    /**
+     * Matomo (formerly Piwik). Most carry a site-id suffix, so they are
+     * matched as patterns.
+     */
+    public static function matomo(Category $category): void
+    {
+        $category
+            ->cookiePattern('^_pk_id', self::T.'.cookies.pk_id')
+            ->cookiePattern('^_pk_ses', self::T.'.cookies.pk_ses')
+            ->cookiePattern('^_pk_ref', self::T.'.cookies.pk_ref')
+            ->cookiePattern('^_pk_cvar', self::T.'.cookies.pk_cvar')
+            ->cookiePattern('^_pk_hsr', self::T.'.cookies.pk_hsr')
+            ->cookie('MATOMO_SESSID', self::T.'.cookies.matomo_sessid');
+
+        self::finish($category);
+    }
+
+    private static function finish(Category $category): void
+    {
+        // The `analytics` section is defined and translated by
+        // fof/cookie-consent, so only the cookies are described here.
+        //
+        // Tracking scripts cannot cleanly undo themselves once loaded, so a
+        // rejection needs a fresh page.
+        $category->reloadOnReject();
+    }
+}

--- a/tests/integration/ConsentTest.php
+++ b/tests/integration/ConsentTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of fof/analytics.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Analytics\Tests\integration;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Analytics scripts must not run until the visitor has consented.
+ *
+ * With fof/cookie-consent installed, the tracking tags are held inert —
+ * `type="text/plain"` with a `data-category`, which the consent library
+ * activates only once the analytics category is accepted. Without it, nothing
+ * changes and the scripts load as before.
+ */
+class ConsentTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    use SeedsSettings;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Seeded rather than set through `setting()`: Extend\Conditional reads
+        // settings while extenders run, which is before the test harness
+        // applies them.
+        $this->seedSettings([
+            'fof-analytics.statusGoogle'       => '1',
+            'fof-analytics.googleTrackingCode' => 'UA-1234567-1',
+        ]);
+
+        $this->extension('fof-analytics', 'fof-cookie-consent');
+    }
+
+    private function html(): string
+    {
+        return (string) $this->send($this->request('GET', '/'))->getBody();
+    }
+
+    #[Test]
+    public function the_tracking_script_is_held_until_consent(): void
+    {
+        $html = $this->html();
+
+        $this->assertStringContainsString('googletagmanager.com/gtag/js', $html);
+        $this->assertStringContainsString('type="text/plain"', $html);
+        $this->assertStringContainsString('data-category="analytics"', $html);
+    }
+
+    #[Test]
+    public function no_tracking_script_executes_directly(): void
+    {
+        $html = $this->html();
+
+        // Every script tag in the analytics block must be gated; an ungated
+        // one would run before the visitor answered.
+        $start = strpos($html, '<!-- Global Site Tag');
+        $block = substr($html, $start, strpos($html, '</head>', $start) - $start);
+
+        $this->assertNotFalse($start, 'analytics block not found');
+        $this->assertSame(
+            substr_count($block, '<script'),
+            substr_count($block, 'data-category="analytics"'),
+            'every analytics script tag should carry a data-category'
+        );
+    }
+
+    #[Test]
+    public function the_analytics_category_is_declared_with_its_cookies(): void
+    {
+        $response = $this->send($this->request('GET', '/api'));
+        $attributes = json_decode($response->getBody()->getContents(), true)['data']['attributes'];
+
+        $categories = $attributes['fof-cookie-consent.categories'];
+
+        $this->assertArrayHasKey('analytics', $categories);
+        $this->assertFalse($categories['analytics']['readOnly']);
+
+        $declared = $categories['analytics']['declaredCookies'];
+
+        // Google Analytics' cookie family.
+        $this->assertContains('/^_ga/', $declared);
+        $this->assertContains('_gid', $declared);
+    }
+}

--- a/tests/integration/DeclaredCookiesTest.php
+++ b/tests/integration/DeclaredCookiesTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of fof/analytics.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Analytics\Tests\integration;
+
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Only providers actually in use should declare cookies. Listing Matomo's
+ * cookies on a forum running Google alone would tell visitors the forum stores
+ * things it does not.
+ */
+class DeclaredCookiesTest extends TestCase
+{
+    use SeedsSettings;
+
+    private const OFF = [
+        'fof-analytics.statusGoogle'       => '0',
+        'fof-analytics.googleTrackingCode' => '',
+        'fof-analytics.googleGTMCode'      => '',
+        'fof-analytics.statusPiwik'        => '0',
+        'fof-analytics.piwikUrl'           => '',
+        'fof-analytics.piwikSiteId'        => '',
+    ];
+
+    private const GOOGLE = [
+        'fof-analytics.statusGoogle'       => '1',
+        'fof-analytics.googleTrackingCode' => 'UA-1234567-1',
+    ];
+
+    private const MATOMO = [
+        'fof-analytics.statusPiwik' => '1',
+        'fof-analytics.piwikUrl'    => 'https://matomo.example/',
+        'fof-analytics.piwikSiteId' => '1',
+    ];
+
+    /**
+     * Settings must exist before the app boots, since `Extend\Conditional`
+     * reads them while extenders run.
+     */
+    private function boot(array $settings): void
+    {
+        $this->seedSettings(array_merge(self::OFF, $settings));
+
+        $this->extension('fof-analytics', 'fof-cookie-consent');
+    }
+
+    private function categories(): array
+    {
+        $response = $this->send($this->request('GET', '/api'));
+
+        return json_decode($response->getBody()->getContents(), true)['data']['attributes']['fof-cookie-consent.categories'];
+    }
+
+    /** @return string[] */
+    private function declared(): array
+    {
+        return $this->categories()['analytics']['declaredCookies'] ?? [];
+    }
+
+    #[Test]
+    public function nothing_is_declared_when_no_provider_is_configured(): void
+    {
+        $this->boot([]);
+
+        $this->assertArrayNotHasKey('analytics', $this->categories());
+    }
+
+    #[Test]
+    public function google_cookies_are_declared_when_google_is_in_use(): void
+    {
+        $this->boot(self::GOOGLE);
+
+        $declared = $this->declared();
+
+        $this->assertContains('/^_ga/', $declared);
+        $this->assertContains('_gid', $declared);
+    }
+
+    #[Test]
+    public function matomo_cookies_are_not_declared_when_only_google_is_in_use(): void
+    {
+        $this->boot(self::GOOGLE);
+
+        $this->assertNotContains('/^_pk_id/', $this->declared());
+    }
+
+    #[Test]
+    public function matomo_cookies_are_declared_when_matomo_is_in_use(): void
+    {
+        $this->boot(self::MATOMO);
+
+        $declared = $this->declared();
+
+        $this->assertContains('/^_pk_id/', $declared);
+        $this->assertNotContains('_gid', $declared, 'Google cookies should not be declared');
+    }
+
+    #[Test]
+    public function both_are_declared_when_both_are_in_use(): void
+    {
+        $this->boot(array_merge(self::GOOGLE, self::MATOMO));
+
+        $declared = $this->declared();
+
+        $this->assertContains('/^_ga/', $declared);
+        $this->assertContains('/^_pk_id/', $declared);
+    }
+
+    #[Test]
+    public function cookies_carry_their_own_translation_keys(): void
+    {
+        $this->boot(self::GOOGLE);
+
+        $category = $this->categories()['analytics'];
+
+        // The `analytics` section itself is owned and translated by
+        // fof/cookie-consent, so nothing is supplied for it here.
+        $this->assertNull($category['titleKey']);
+
+        // The cookies are ours to describe, though.
+        $this->assertSame('fof-analytics.forum.consent.cookies.gid', $category['descriptions']['_gid']);
+        $this->assertSame('fof-analytics.forum.consent.cookies.ga', $category['descriptions']['/^_ga/']);
+    }
+
+    #[Test]
+    public function google_is_ignored_when_switched_off_despite_a_tracking_code(): void
+    {
+        $this->boot(['fof-analytics.googleTrackingCode' => 'UA-1234567-1']);
+
+        $this->assertArrayNotHasKey('analytics', $this->categories());
+    }
+}

--- a/tests/integration/SeedsSettings.php
+++ b/tests/integration/SeedsSettings.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of fof/analytics.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Analytics\Tests\integration;
+
+/**
+ * Writes settings straight to the test database before the app boots.
+ *
+ * `TestCase::setting()` applies its values through an extender that runs
+ * *after* OverrideExtensionManagerForTests has already booted every extension
+ * — so anything read during boot, such as `Extend\Conditional::whenSetting`,
+ * sees nothing. Writing the rows first is the only way to have them in place
+ * by the time extenders run.
+ */
+trait SeedsSettings
+{
+    use \Flarum\Testing\integration\UsesTmpDir;
+
+    protected function seedSettings(array $settings): void
+    {
+        $config = include $this->tmpDir().'/config.php';
+        $db = $config['database'];
+
+        if ($db['driver'] === 'sqlite') {
+            $path = $db['database'];
+
+            // Relative paths are resolved against the test installation.
+            if (! str_starts_with($path, '/')) {
+                $path = $this->tmpDir().'/'.$path;
+            }
+
+            $pdo = new \PDO('sqlite:'.$path);
+        } else {
+            $pdo = new \PDO(
+                sprintf('mysql:host=%s;port=%s;dbname=%s', $db['host'], $db['port'] ?? 3306, $db['database']),
+                $db['username'],
+                $db['password']
+            );
+        }
+
+        $prefix = $db['prefix'] ?? '';
+
+        foreach ($settings as $key => $value) {
+            $pdo->prepare("DELETE FROM {$prefix}settings WHERE `key` = ?")->execute([$key]);
+            $pdo->prepare("INSERT INTO {$prefix}settings (`key`, `value`) VALUES (?, ?)")->execute([$key, $value]);
+        }
+    }
+}

--- a/tests/integration/SeedsSettings.php
+++ b/tests/integration/SeedsSettings.php
@@ -24,11 +24,9 @@ trait SeedsSettings
 {
     use \Flarum\Testing\integration\UsesTmpDir;
 
-    protected function seedSettings(array $settings): void
+    /** Connect straight to the test database, whichever driver it uses. */
+    private function connect(array $db): \PDO
     {
-        $config = include $this->tmpDir().'/config.php';
-        $db = $config['database'];
-
         if ($db['driver'] === 'sqlite') {
             $path = $db['database'];
 
@@ -37,20 +35,37 @@ trait SeedsSettings
                 $path = $this->tmpDir().'/'.$path;
             }
 
-            $pdo = new \PDO('sqlite:'.$path);
-        } else {
-            $pdo = new \PDO(
-                sprintf('mysql:host=%s;port=%s;dbname=%s', $db['host'], $db['port'] ?? 3306, $db['database']),
-                $db['username'],
-                $db['password']
-            );
+            return new \PDO('sqlite:'.$path);
         }
 
+        $pgsql = $db['driver'] === 'pgsql';
+
+        // MariaDB is driven by PDO's mysql driver.
+        $driver = $pgsql ? 'pgsql' : 'mysql';
+        $port = $db['port'] ?? ($pgsql ? 5432 : 3306);
+
+        return new \PDO(
+            sprintf('%s:host=%s;port=%s;dbname=%s', $driver, $db['host'], $port, $db['database']),
+            $db['username'],
+            $db['password']
+        );
+    }
+
+    protected function seedSettings(array $settings): void
+    {
+        $config = include $this->tmpDir().'/config.php';
+        $db = $config['database'];
+
+        $pdo = $this->connect($db);
+
+        // `key` is reserved in both MySQL and PostgreSQL, but each quotes it
+        // differently.
+        $key = $db['driver'] === 'pgsql' ? '"key"' : '`key`';
         $prefix = $db['prefix'] ?? '';
 
-        foreach ($settings as $key => $value) {
-            $pdo->prepare("DELETE FROM {$prefix}settings WHERE `key` = ?")->execute([$key]);
-            $pdo->prepare("INSERT INTO {$prefix}settings (`key`, `value`) VALUES (?, ?)")->execute([$key, $value]);
+        foreach ($settings as $setting => $value) {
+            $pdo->prepare("DELETE FROM {$prefix}settings WHERE $key = ?")->execute([$setting]);
+            $pdo->prepare("INSERT INTO {$prefix}settings ($key, value) VALUES (?, ?)")->execute([$setting, $value]);
         }
     }
 }

--- a/tests/integration/SeedsSettings.php
+++ b/tests/integration/SeedsSettings.php
@@ -33,7 +33,7 @@ trait SeedsSettings
             $path = $db['database'];
 
             // Relative paths are resolved against the test installation.
-            if (! str_starts_with($path, '/')) {
+            if (!str_starts_with($path, '/')) {
                 $path = $this->tmpDir().'/'.$path;
             }
 

--- a/tests/integration/WithoutCookieConsentTest.php
+++ b/tests/integration/WithoutCookieConsentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of fof/analytics.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Analytics\Tests\integration;
+
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Most installs will not have fof/cookie-consent. Referencing its classes
+ * outside a `whenExtensionEnabled` guard is fatal on those forums, so this
+ * boots analytics on its own and checks nothing breaks.
+ */
+class WithoutCookieConsentTest extends TestCase
+{
+    use SeedsSettings;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seedSettings([
+            'fof-analytics.statusGoogle'       => '1',
+            'fof-analytics.googleTrackingCode' => 'UA-1234567-1',
+            'fof-analytics.statusPiwik'        => '0',
+        ]);
+
+        // Deliberately NOT enabling fof-cookie-consent.
+        $this->extension('fof-analytics');
+    }
+
+    #[Test]
+    public function the_forum_boots_without_cookie_consent_installed(): void
+    {
+        $response = $this->send($this->request('GET', '/'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function tracking_still_loads_normally(): void
+    {
+        $html = (string) $this->send($this->request('GET', '/'))->getBody();
+
+        $this->assertStringContainsString('googletagmanager.com/gtag/js', $html);
+
+        // Nothing to gate against, so the script runs as it always did.
+        $this->assertStringNotContainsString('data-category="analytics"', $html);
+    }
+}

--- a/tests/integration/setup.php
+++ b/tests/integration/setup.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of fof/analytics.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Testing\integration\Setup\SetupScript;
+
+require __DIR__.'/../../vendor/autoload.php';
+
+$setup = new SetupScript();
+
+$setup->run();

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+         bootstrap="../vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="INTEGRATION">
+            <directory>./integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Depends on [fof/cookie-consent#53](https://github.com/FriendsOfFlarum/cookie-consent/pull/53), now merged. Requires `fof/cookie-consent` `^2.0.0`, which resolves to `2.0.0-beta.1`.

## What changes

Analytics scripts load for everyone today, setting Google and Matomo cookies before anyone is asked. With `fof/cookie-consent` installed they are now held inert:

```html
<script type="text/plain" data-category="analytics" async src="https://www.googletagmanager.com/gtag/js?id=..."></script>
```

The browser treats that as data, so it never fetches the script and never runs it. No request, no cookie. On acceptance the consent library swaps the type back and tracking starts.

## Soft dependency

Declared through `Extend\Conditional`, so nothing changes on forums without `fof/cookie-consent` — the scripts load exactly as before. `optional-dependencies` makes it boot first when present.

## Only what is in use

Each provider is declared only when switched on, so a forum running Google alone does not tell visitors it stores Matomo's cookies.

Every cookie carries a translation key describing what it does, so the preferences dialog explains rather than lists:

| Cookie | Purpose |
| --- | --- |
| `_ga` | Tells visits apart, so repeat visits are not counted as new people |
| `_gid` | Tells visits apart, kept for 24 hours |
| `_pk_ses` | Tracks the current visit, kept for 30 minutes |

The `analytics` category itself is defined and translated by `fof/cookie-consent`, so several extensions contributing to it read consistently.

## Frontend fix

The initial `gtag('config', ...)` ran in a `setTimeout`, before consent, where `gtag` did not yet exist — the call was lost and only later page views tracked. It now falls back to configuring on `cc:onConsent`.

## Tests

Integration tests are added (there were none), covering:

- tracking tags are gated, and every script in the block carries a category
- each provider declares only when in use
- cookies carry their own translation keys
- **the forum boots with `fof/cookie-consent` absent** — referencing its classes unguarded would be fatal on most installs

`enable_backend_testing` is now on, so CI runs these.

## Verify locally

Requires `fof/cookie-consent` on the PR branch:

```sh
composer test:setup
composer test
```

